### PR TITLE
feat: skip no child element

### DIFF
--- a/goinspect.go
+++ b/goinspect.go
@@ -65,7 +65,7 @@ func Dump(c *Config, g *Graph, nodes []*Node) error {
 		prefix := strings.Join(parts[:len(parts)-1], "/") + "/"
 		if len(path) == 1 {
 			node := path[0]
-			if len(node.From) == 0 && c.NeedName(node.Name) {
+			if len(node.From) == 0 && len(node.To) > 0 && c.NeedName(node.Name) {
 				name := strings.ReplaceAll(path[len(path)-1].Value.Object.String(), prefix, "")
 				fmt.Printf("\n%s%s\n", strings.Repeat("  ", len(path)), name)
 			}


### PR DESCRIPTION
e.g. `go run cmd/goinspect/main.go --pkg golang.org/x/tools/go/packages`

```diff
--- /tmp/before	2022-09-10 15:58:10.043994534 +0900
+++ /tmp/after	2022-09-10 15:58:22.673994363 +0900
@@ -1,12 +1,8 @@
 package golang.org/x/tools/go/packages
 
-  type packages.OverlayJSON struct{Replace map[string]string "json:\"replace,omitempty\""}
-
   type packages.LoadMode int
     func (packages.LoadMode).String() string
 
-  type packages.Config struct{Mode packages.LoadMode; Context context.Context; Logf func(format string, args ...interface{}); Dir string; Env []string; gocmdRunner *golang.org/x/tools/internal/gocommand.Runner; BuildFlags []string; modFile string; modFlag string; Fset *go/token.FileSet; ParseFile func(fset *go/token.FileSet, filename string, src []byte) (*go/ast.File, error); Tests bool; Overlay map[string][]byte}
-
   func packages.Load(cfg *packages.Config, patterns ...string) ([]*packages.Package, error)
 
   type packages.Package struct{ID string; Name string; PkgPath string; Errors []packages.Error; GoFiles []string; CompiledGoFiles []string; OtherFiles []string; EmbedFiles []string; EmbedPatterns []string; IgnoredFiles []string; ExportFile string; Imports map[string]*packages.Package; Types *go/types.Package; Fset *go/token.FileSet; IllTyped bool; Syntax []*go/ast.File; TypesInfo *go/types.Info; TypesSizes go/types.Sizes; forTest string; depsErrors []*golang.org/x/tools/internal/packagesinternal.PackageError; Module *packages.Module}
@@ -14,14 +10,8 @@
     func (*packages.Package).UnmarshalJSON(b []byte) error
     func (*packages.Package).String() string
 
-  type packages.Module struct{Path string; Version string; Replace *packages.Module; Time *time.Time; Main bool; Indirect bool; Dir string; GoMod string; GoVersion string; Error *packages.ModuleError}
-
-  type packages.ModuleError struct{Err string}
-
   type packages.Error struct{Pos string; Msg string; Kind packages.ErrorKind}
     func (packages.Error).Error() string
-
-  type packages.ErrorKind int
           field ParseFile func(fset *go/token.FileSet, filename string, src []byte) (*go/ast.File, error)
         func (packages.importerFunc).Import(path string) (*go/types.Package, error)
 
@@ -29,13 +19,9 @@
     func packages.Visit(pkgs []*packages.Package, pre func(*packages.Package) bool, post func(*packages.Package))
 package golang.org/x/tools/go/packages
 
-  type packages.OverlayJSON struct{Replace map[string]string "json:\"replace,omitempty\""}
-
   type packages.LoadMode int
     func (packages.LoadMode).String() string
 
-  type packages.Config struct{Mode packages.LoadMode; Context context.Context; Logf func(format string, args ...interface{}); Dir string; Env []string; gocmdRunner *golang.org/x/tools/internal/gocommand.Runner; BuildFlags []string; modFile string; modFlag string; Fset *go/token.FileSet; ParseFile func(fset *go/token.FileSet, filename string, src []byte) (*go/ast.File, error); Tests bool; Overlay map[string][]byte}
-
   func packages.Load(cfg *packages.Config, patterns ...string) ([]*packages.Package, error)
 
   type packages.Package struct{ID string; Name string; PkgPath string; Errors []packages.Error; GoFiles []string; CompiledGoFiles []string; OtherFiles []string; EmbedFiles []string; EmbedPatterns []string; IgnoredFiles []string; ExportFile string; Imports map[string]*packages.Package; Types *go/types.Package; Fset *go/token.FileSet; IllTyped bool; Syntax []*go/ast.File; TypesInfo *go/types.Info; TypesSizes go/types.Sizes; forTest string; depsErrors []*golang.org/x/tools/internal/packagesinternal.PackageError; Module *packages.Module}
@@ -43,14 +29,8 @@
     func (*packages.Package).UnmarshalJSON(b []byte) error
     func (*packages.Package).String() string
 
-  type packages.Module struct{Path string; Version string; Replace *packages.Module; Time *time.Time; Main bool; Indirect bool; Dir string; GoMod string; GoVersion string; Error *packages.ModuleError}
-
-  type packages.ModuleError struct{Err string}
-
   type packages.Error struct{Pos string; Msg string; Kind packages.ErrorKind}
     func (packages.Error).Error() string
-
-  type packages.ErrorKind int
           field ParseFile func(fset *go/token.FileSet, filename string, src []byte) (*go/ast.File, error)
         func (packages.importerFunc).Import(path string) (*go/types.Package, error)
 
```